### PR TITLE
Remove SSL certificate env var and volumes

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -117,4 +117,4 @@ JACKSON_IDP_ENABLED=true
 # Optional Configuration
 SUPPORT_EMAIL="support@greptile.com" 
 HIDE_SOCIALS="false"
-
+SSL_CERTS_PATH="" # Path to SSL certificate - Example "/custom/path/to/certs/ca-certificates.crt"

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -117,4 +117,4 @@ JACKSON_IDP_ENABLED=true
 # Optional Configuration
 SUPPORT_EMAIL="support@greptile.com" 
 HIDE_SOCIALS="false"
-SSL_CERTS_PATH="" # Path to SSL certificate - Example "/custom/path/to/certs/ca-certificates.crt"
+CUSTOM_FILE_PATH="" # Path to a file that should be included in the container - Example "/custom/path/to/certs/ca-certificates.crt"

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -17,9 +17,6 @@ REDIS_HOST="" #should be set to your Redis host. If using Elasticache, this will
 REDIS_PORT="6379" #should be set to your Redis port (usually 6379)
 REDIS_PASSWORD="" #should be set to your Redis password
 
-# SSL_CERTS_PATH="/custom/path/to/certs" # Optional: Override the default SSL certificates path (/opt/greptile/certs), copy here with -L to flatten symlinks
-# SSL_CERT_NAME="" # Optional: Name of the specific certificate file to use, e.g. "ca-certificates.crt"
-
 
 # Service URLs
 API_URL="http://greptile_api_service:3002" #leave unchanged

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -161,8 +161,6 @@ services:
         condition: service_started
     ports:
       - "3002:3002"
-    volumes:
-      - ssl-certs:/greptile-certs:ro
 
   greptile_auth_service:
     image: ${ECR_REGISTRY}/greptile/auth:${TAG}
@@ -177,8 +175,6 @@ services:
       - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "3001:3001"
-    volumes:
-      - ssl-certs:/greptile-certs:ro
 
   greptile_indexer_chunker:
     image: ${ECR_REGISTRY}/greptile/chunker:${TAG}
@@ -208,7 +204,6 @@ services:
         condition: service_started
     volumes:
       - shared-mnt:/mnt
-      - ssl-certs:/greptile-certs:ro
 
   greptile_indexer_summarizer:
     image: ${ECR_REGISTRY}/greptile/summarizer:${TAG}
@@ -242,7 +237,6 @@ services:
       - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     volumes:
       - shared-mnt:/mnt
-      - ssl-certs:/greptile-certs:ro
 
   greptile_query_service:
     image: ${ECR_REGISTRY}/greptile/query:${TAG}
@@ -277,8 +271,6 @@ services:
       - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "8081:8081"
-    volumes:
-      - ssl-certs:/greptile-certs:ro
 
   greptile_web_service:
     image: ${ECR_REGISTRY}/greptile/web:${TAG}
@@ -326,8 +318,6 @@ services:
       - HIDE_SOCIALS=${HIDE_SOCIALS}
     ports:
       - "3000:3000"
-    volumes:
-      - ssl-certs:/greptile-certs:ro
 
   greptile_github_service:
     image: ${ECR_REGISTRY}/greptile/github:${TAG}
@@ -362,8 +352,6 @@ services:
       - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "3010:3010"
-    volumes:
-      - ssl-certs:/greptile-certs:ro
 
   greptile_vector_db_migration:
     image: ${ECR_REGISTRY}/greptile/vectordb-migration:${TAG}
@@ -453,8 +441,6 @@ services:
       - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "5225:5225"
-    volumes:
-      - ssl-certs:/greptile-certs:ro
     # depends_on:
     #   greptile_db_migration:
     #     condition: service_completed_successfully
@@ -468,8 +454,3 @@ volumes:
   hatchet_certs:
   caddy_data:
   caddy_config:
-  ssl-certs:
-    driver_opts:
-      type: none
-      o: bind
-      device: ${SSL_CERTS_PATH:-/opt/greptile/certs}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -438,11 +438,11 @@ services:
     #     condition: service_completed_successfully
 
 volumes:
-  shared-mnt:
-  hatchet_postgres_data:
-  hatchet_rabbitmq_data:
-  hatchet_rabbitmq.conf:
-  hatchet_config:
-  hatchet_certs:
-  caddy_data:
-  caddy_config:
+  shared-mnt: {}
+  hatchet_postgres_data: {}
+  hatchet_rabbitmq_data: {}
+  hatchet_rabbitmq.conf: {}
+  hatchet_config: {}
+  hatchet_certs: {}
+  caddy_data: {}
+  caddy_config: {}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -155,7 +155,6 @@ services:
       - NODE_ENV=production
       - X_AWS_REGION=${AWS_REGION}
       - PORT=3002
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     depends_on:
       hatchet-api:
         condition: service_started
@@ -172,7 +171,6 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - DATABASE_URL=${DATABASE_URL}
       - EMAIL_FROM=${AUTH_EMAIL_FROM}
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "3001:3001"
 
@@ -198,7 +196,6 @@ services:
       - BATCH_SIZE=${BATCH_SIZE}
       - PARENT_DIR=/mnt/data/
       - PORT=3003
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     depends_on:
       hatchet-engine:
         condition: service_started
@@ -234,7 +231,6 @@ services:
       - AZURE_OPENAI_URL=${AZURE_OPENAI_URL}
       - AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME=${AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME}
       - AZURE_OPENAI_EMBEDDINGS_API_VERSION=${AZURE_OPENAI_EMBEDDINGS_API_VERSION}
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     volumes:
       - shared-mnt:/mnt
 
@@ -268,7 +264,6 @@ services:
       - AZURE_OPENAI_URL=${AZURE_OPENAI_URL}
       - AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME=${AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME}
       - AZURE_OPENAI_EMBEDDINGS_API_VERSION=${AZURE_OPENAI_EMBEDDINGS_API_VERSION}
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "8081:8081"
 
@@ -313,7 +308,6 @@ services:
       - GITLAB_ENABLED=${GITLAB_ENABLED}
       - SLACK_ENABLED=${SLACK_ENABLED}
       - LINEAR_ENABLED=${LINEAR_ENABLED}
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
       - SUPPORT_EMAIL=${SUPPORT_EMAIL}
       - HIDE_SOCIALS=${HIDE_SOCIALS}
     ports:
@@ -349,7 +343,6 @@ services:
       - AZURE_OPENAI_URL=${AZURE_OPENAI_URL}
       - AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME=${AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME}
       - AZURE_OPENAI_EMBEDDINGS_API_VERSION=${AZURE_OPENAI_EMBEDDINGS_API_VERSION}
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "3010:3010"
 
@@ -438,7 +431,6 @@ services:
       - PORT=5225
       - AWS_REGION=${AWS_REGION}
       - DO_NOT_TRACK=1
-      - NODE_EXTRA_CA_CERTS=/greptile-certs/${SSL_CERT_NAME}
     ports:
       - "5225:5225"
     # depends_on:

--- a/docker/start_greptile.sh
+++ b/docker/start_greptile.sh
@@ -74,8 +74,8 @@ echo "Database migrations completed successfully."
 echo "Starting core services..."
 docker-compose up -d --force-recreate "${GREPTILE_SERVICES[@]}"
 
-# Copy SSL certificates to all services if SSL_CERTS_PATH is set
-if [ -n "$SSL_CERTS_PATH" ]; then
+# Copy SSL certificates to all services if CUSTOM_FILE_PATH is set
+if [ -n "$CUSTOM_FILE_PATH" ]; then
     echo "Copying SSL certificates to services..."
     for service in "${GREPTILE_SERVICES[@]}"
     do
@@ -83,8 +83,8 @@ if [ -n "$SSL_CERTS_PATH" ]; then
         container_id=$(docker-compose ps -q $service 2>/dev/null)
         if [ -n "$container_id" ]; then
             echo "Copying to $service (container: $container_id)..."
-            docker exec $container_id mkdir -p /app/ssl_certs
-            docker cp $SSL_CERTS_PATH $container_id:/app/ssl_certs
+            docker exec $container_id mkdir -p /app/custom_data
+            docker cp $CUSTOM_FILE_PATH $container_id:/app/custom_data/
         else
             echo "Warning: Could not find container for service $service"
         fi

--- a/docker/start_greptile.sh
+++ b/docker/start_greptile.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Define the list of services
+GREPTILE_SERVICES=(
+    greptile_api_service
+    greptile_auth_service
+    greptile_indexer_chunker
+    greptile_indexer_summarizer
+    greptile_query_service
+    greptile_web_service
+    greptile_github_service
+)
+
 # Function to set GitHub environment variables for backwards compatibility
 # TODO The github env variables should be refactored in the service side app logic
 #  and then this helper function can be removed
@@ -31,6 +42,7 @@ set_github_env() {
     fi
 }
 
+
 # Check if Docker is accessible
 if ! docker info > /dev/null 2>&1; then
     echo "Error: Cannot access Docker. Please check that:"
@@ -60,14 +72,24 @@ echo "Database migrations completed successfully."
 
 # Start the core services
 echo "Starting core services..."
-docker-compose up -d --force-recreate \
-    greptile_api_service \
-    greptile_auth_service \
-    greptile_indexer_chunker \
-    greptile_indexer_summarizer \
-    greptile_query_service \
-    greptile_web_service \
-    greptile_github_service
+docker-compose up -d --force-recreate "${GREPTILE_SERVICES[@]}"
+
+# Copy SSL certificates to all services if SSL_CERTS_PATH is set
+if [ -n "$SSL_CERTS_PATH" ]; then
+    echo "Copying SSL certificates to services..."
+    for service in "${GREPTILE_SERVICES[@]}"
+    do
+        # Get the container ID for the service
+        container_id=$(docker-compose ps -q $service 2>/dev/null)
+        if [ -n "$container_id" ]; then
+            echo "Copying to $service (container: $container_id)..."
+            docker exec $container_id mkdir -p /app/ssl_certs
+            docker cp $SSL_CERTS_PATH $container_id:/app/ssl_certs
+        else
+            echo "Warning: Could not find container for service $service"
+        fi
+    done
+fi
 
 echo "All Greptile services have been started."
 echo "You can check service status with: docker-compose ps"


### PR DESCRIPTION
Remove the the SSL environment variables and any volumes associated with SSL certificates.

When the SSL environment variable is undefined, docker-compose will fall back to `/opt/greptile/certs`. If that directory does not exist on the host, the entire container setup won't come up.

Replace the current logic with a `docker cp` cmd that copies the files from the host into the container.