### PR TITLE
add global gitlab token to api app

### DIFF
--- a/greptile-helm/templates/deployments.yaml
+++ b/greptile-helm/templates/deployments.yaml
@@ -254,6 +254,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "greptile.fullname" . }}-secrets
                   key: GREPTILE_ADMIN_KEY
+            - name: GLOBAL_GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "greptile.fullname" . }}-secrets
+                  key: GLOBAL_GITLAB_TOKEN
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
 {{- end }}


### PR DESCRIPTION
Admin API to associate repos with orgs will fallback to Gitlab access token provided by this env - it is already set for web need to do the same for api app. 