### PR TITLE
Sync Kubernetes llmproxy config with v0.3.133

### DIFF
--- a/deploy/kubernetes/charts/greptile/files/llmproxy-config.yaml
+++ b/deploy/kubernetes/charts/greptile/files/llmproxy-config.yaml
@@ -24,30 +24,71 @@ model_list:
       model: openai/text-embedding-*
       api_base: "os.environ/OPENAI_BASE_URL"
       api_key: "os.environ/OPENAI_API_KEY"
-  - model_name: bedrock/*
+  - model_name: memory-learning
     litellm_params:
-      model: bedrock/*
-      aws_access_key_id: "os.environ/AWS_ACCESS_KEY_ID"
-      aws_secret_access_key: "os.environ/AWS_SECRET_ACCESS_KEY"
-      aws_region_name: "os.environ/AWS_REGION_NAME"
+      model: anthropic/claude-sonnet-4-6
+      api_base: "os.environ/ANTHROPIC_BASE_URL"
+      api_key: "os.environ/ANTHROPIC_API_KEY"
+      timeout: 300
+  #  Example of bedrock
+  # - model_name: bedrock/*
+  #   litellm_params:
+  #     model: bedrock/*
+  #     aws_access_key_id: "os.environ/AWS_ACCESS_KEY_ID"
+  #     aws_secret_access_key: "os.environ/AWS_SECRET_ACCESS_KEY"
+  #     aws_region_name: "os.environ/AWS_REGION_NAME"
+  # Example of Azure OpenAI models
+  # - model_name: summarizer-pool
+  #   litellm_params:
+  #     model: azure/gpt-4o-mini
+  #     api_base: "os.environ/AZURE_OPENAI_BASE_URL"
+  #     api_key: "os.environ/AZURE_OPENAI_API_KEY"
+  #     api_version: "os.environ/AZURE_OPENAI_API_VERSION"
+  #   model_info:
+  #     base_model: gpt-4o-mini
 
 litellm_settings:
   drop_params: True
   num_retries: 3 # retry call 3 times on each model_name
   allowed_fails: 3
+  stream_timeout: 600 # 10 min timeout for streaming responses
+
+batch_settings:
+  providers:
+    anthropic:
+      model_patterns:
+        - claude-*
+    openai:
+      model_patterns:
+        - gpt-4o*
+        - gpt-5*
+        - chatgpt-*
 
 router_settings:
   routing_strategy: simple-shuffle # Literal["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"]
   model_group_alias:
     "gpt": "gpt-5.2"
     "codex": "gpt-5.2-codex"  # OpenAI Codex SDK model alias
+    "alternate-review": "gpt-5.2-codex"
+    "api-chat-completion": "gpt-5.4-nano"
+    "addressed-judge": "gpt-5.4-nano"
+    "acknowledged-judge": "gpt-5.4-mini"
+    "comment-analytics": "gpt-5.4-nano"
+    "comment-classifier": "gpt-5.4-nano"
+    "post-review-gate": "gpt-5.4-nano"
+    "post-review-deduplication": "gpt-5.4-nano"
+    "first-week-stats": "claude-haiku-4-5-20251001"
+    "rule-optimization": "gpt-5.4-nano"
+    "severity-reclassifier": "gpt-5.4-nano"
     "memory-embeddings": "text-embedding-3-small"
     "indexer-embeddings": "text-embedding-3-small"
     "similarity-embeddings": "text-embedding-3-small"
-    "jobs-summarizer": "gpt-5-nano"
+    "weekly-digest": "claude-haiku-4-5-20251001"
+    "jobs-summarizer": "gpt-5"
     "memory-clustering": "claude-sonnet-4-6"
-    "memory-learning": "claude-sonnet-4-6"
     "review": "claude-sonnet-4-6" # backward-compat alias; avoid alias chaining
+    "review-deep": "claude-opus-4-6"
+    "review-light": "claude-haiku-4-5-20251001"
     "review-sonnet": "claude-sonnet-4-6"
     "review-opus": "claude-opus-4-6"
     "review-haiku": "claude-haiku-4-5-20251001"
@@ -55,11 +96,12 @@ router_settings:
     "summarizer": "summarizer-pool"
     "summarizer-fast": "summarizer-pool"
     "engine-mini": "claude-sonnet-4-6"
-    "claude-code": "claude-sonnet-4-5"
+    "claude-code": "claude-sonnet-4-6"
     "claude-haiku": "claude-haiku-4-5-20251001"
     "claude-opus": "claude-opus-4-6"
+
   num_retries: 2
-  timeout: 30 # seconds
+  timeout: 120 # seconds
 
 general_settings:
   forward_client_headers_to_llm_api: true


### PR DESCRIPTION
## Summary
- mirror the llmproxy v0.3.133 config changes from PR #78 into the standalone Kubernetes Helm deployment
- add the new model aliases, batching settings, and longer router/stream timeouts
- replace the active bedrock catch-all entry with the new commented example block, matching the docker-compose config

## Validation
- helm lint deploy/kubernetes/charts/greptile
- helm template greptile deploy/kubernetes/charts/greptile -f deploy/kubernetes/charts/profiles/values.user.example.yaml >/dev/null
- ./deploy/kubernetes/scripts/validate.sh *(fails after lint because the repo is missing deploy/kubernetes/charts/profiles/values-prod.yaml, values-staging.yaml, and values-dev.yaml)*