### PR TITLE
Add review-opus-4-8 and reply-agent llmproxy aliases

### DIFF
--- a/deploy/docker-compose/llmproxy-config.yaml
+++ b/deploy/docker-compose/llmproxy-config.yaml
@@ -88,11 +88,13 @@ router_settings:
     "memory-clustering": "claude-sonnet-4-6"
     "review": "claude-sonnet-4-6" # backward-compat alias; avoid alias chaining
     "review-deep": "claude-opus-4-6"
+    "review-opus-4-8": "claude-opus-4-8"
     "review-light": "claude-haiku-4-5-20251001"
     "review-sonnet": "claude-sonnet-4-6"
     "review-opus": "claude-opus-4-6"
     "review-haiku": "claude-haiku-4-5-20251001"
     "refiner": "claude-sonnet-4-6"
+    "reply-agent": "claude-sonnet-4-6"
     "summarizer": "summarizer-pool"
     "summarizer-fast": "summarizer-pool"
     "engine-mini": "claude-sonnet-4-6"

--- a/deploy/kubernetes/charts/greptile/files/llmproxy-config.yaml
+++ b/deploy/kubernetes/charts/greptile/files/llmproxy-config.yaml
@@ -88,11 +88,13 @@ router_settings:
     "memory-clustering": "claude-sonnet-4-6"
     "review": "claude-sonnet-4-6" # backward-compat alias; avoid alias chaining
     "review-deep": "claude-opus-4-6"
+    "review-opus-4-8": "claude-opus-4-8"
     "review-light": "claude-haiku-4-5-20251001"
     "review-sonnet": "claude-sonnet-4-6"
     "review-opus": "claude-opus-4-6"
     "review-haiku": "claude-haiku-4-5-20251001"
     "refiner": "claude-sonnet-4-6"
+    "reply-agent": "claude-sonnet-4-6"
     "summarizer": "summarizer-pool"
     "summarizer-fast": "summarizer-pool"
     "engine-mini": "claude-sonnet-4-6"


### PR DESCRIPTION
## Summary
- Add `review-opus-4-8` → `claude-opus-4-8` model group alias
- Add `reply-agent` → `claude-sonnet-4-6` model group alias
- Update both Kubernetes and docker-compose llmproxy configs to stay in sync

## Test plan
- [ ] Deploy updated llmproxy config and verify `review-opus-4-8` routes to `claude-opus-4-8`
- [ ] Verify `reply-agent` routes to `claude-sonnet-4-6`
- [ ] Confirm existing review aliases are unchanged


Made with [Cursor](https://cursor.com)