### PR TITLE
Set default experiment variant and dynamic router for on-prem deploys

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -154,7 +154,8 @@ SMTP_TLS='true'
 SMTP_REJECT_UNAUTHORIZED='true'
 
 # Control variant for the default agent model
-DEFAULT_EXPERIMENT_VARIANT='opus-v8'
+DEFAULT_EXPERIMENT_VARIANT='rsv11-stndrd4'
+DEFAULT_DYNAMIC_ROUTER='router:reviewNumber:rsv11-stndrd4:rsv16-stndrd4-regated'
 
 # Memory and Custom Context
 LEARN_PROCEDURAL_MEMORY='true'

--- a/deploy/kubernetes/charts/greptile/values.schema.json
+++ b/deploy/kubernetes/charts/greptile/values.schema.json
@@ -124,7 +124,8 @@
         "authSamlOnly": { "type": "string" },
         "learnProceduralMemory": { "type": "string" },
         "useProceduralMemory": { "type": "string" },
-        "defaultExperimentVariant": { "type": "string" }
+        "defaultExperimentVariant": { "type": "string" },
+        "defaultDynamicRouter": { "type": "string" }
       }
     },
     "github": {

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -116,7 +116,8 @@ appConfig:
   authSamlOnly: "false"
   learnProceduralMemory: "true"
   useProceduralMemory: "true"
-  defaultExperimentVariant: "opus-v8"
+  defaultExperimentVariant: "rsv11-stndrd4"
+  defaultDynamicRouter: "router:reviewNumber:rsv11-stndrd4:rsv16-stndrd4-regated"
 
 github:
   enabled: "false"
@@ -397,6 +398,7 @@ components:
       LEARN_PROCEDURAL_MEMORY: "{{ .Values.appConfig.learnProceduralMemory }}"
       USE_PROCEDURAL_MEMORY: "{{ .Values.appConfig.useProceduralMemory }}"
       DEFAULT_EXPERIMENT_VARIANT: "{{ .Values.appConfig.defaultExperimentVariant }}"
+      DEFAULT_DYNAMIC_ROUTER: "{{ .Values.appConfig.defaultDynamicRouter }}"
     envFromConfigMap: []
     envFromSecret: []
     volumes:


### PR DESCRIPTION
## Summary
- Update the default worker experiment variant from `opus-v8` to `rsv11-stndrd4` in Kubernetes and Docker Compose.
- Add `DEFAULT_DYNAMIC_ROUTER` with review-number-based routing (`router:reviewNumber:rsv11-stndrd4:rsv16-stndrd4-regated`) to the Kubernetes worker env and Docker Compose `.env.example`.
- Extend the Helm values schema with `appConfig.defaultDynamicRouter`.

## Test plan
- [ ] `helm template` renders worker env vars with the new defaults
- [ ] Fresh Docker Compose setup from `.env.example` includes both env vars on `greptile-worker`
- [ ] Existing deployments can override via `values.user.yaml` (K8s) or `.env` (Docker Compose) if needed


Made with [Cursor](https://cursor.com)