### PR TITLE
Scale summarizer replicas to zero in on-prem deploys

### DIFF
--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -223,6 +223,7 @@ services:
       - greptile
 
   greptile-indexer-summarizer:
+    # Disabled (0 replicas) for now; kept for future compatibility since it's still referenced.
     image: ${CONTAINER_REGISTRY}/summarizer:${GREPTILE_TAG}
     restart: on-failure
     deploy:

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -226,7 +226,7 @@ services:
     image: ${CONTAINER_REGISTRY}/summarizer:${GREPTILE_TAG}
     restart: on-failure
     deploy:
-      replicas: 1
+      replicas: 0
     env_file:
       - .env.greptile-generated
       - .env.hatchet-generated

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -336,6 +336,7 @@ components:
 
   summarizer:
     enabled: true
+    # Disabled (0 replicas) for now; kept for future compatibility since it's still referenced.
     replicas: 0
     image:
       repository: summarizer

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -336,7 +336,7 @@ components:
 
   summarizer:
     enabled: true
-    replicas: 1
+    replicas: 0
     image:
       repository: summarizer
       tag: ""


### PR DESCRIPTION
## Summary
- Set the Kubernetes `summarizer` component default replicas from `1` to `0`.
- Set the Docker Compose `greptile-indexer-summarizer` service default replicas from `1` to `0`.

The summarizer deployment/service definition remains in place so it can be scaled back up when needed.

## Test plan
- [ ] `helm template` renders the summarizer deployment with `replicas: 0`
- [ ] `docker compose --profile greptile config` shows `greptile-indexer-summarizer` with `replicas: 0`
- [ ] Other Greptile services continue to start normally without the summarizer running


Made with [Cursor](https://cursor.com)