### PR TITLE
Disable TREX settings and repo clusters in on-prem deploys

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -114,6 +114,8 @@ BENCHMARK='false'
 ANALYTICS='false'
 ONPREM='true'
 NEW_WORKER_LOAD='100'
+TREX_SETTINGS_ENABLED='false'
+REPO_CLUSTERS_ENABLED='false'
 
 # ========= Optional values ===============
 

--- a/deploy/kubernetes/charts/greptile/values.schema.json
+++ b/deploy/kubernetes/charts/greptile/values.schema.json
@@ -125,7 +125,9 @@
         "learnProceduralMemory": { "type": "string" },
         "useProceduralMemory": { "type": "string" },
         "defaultExperimentVariant": { "type": "string" },
-        "defaultDynamicRouter": { "type": "string" }
+        "defaultDynamicRouter": { "type": "string" },
+        "trexSettingsEnabled": { "type": "string" },
+        "repoClustersEnabled": { "type": "string" }
       }
     },
     "github": {

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -111,6 +111,8 @@ env:
     GITHUB_ENTERPRISE_API_URL: "{{ include \"greptile.githubEnterpriseApiUrl\" . }}"
     GITHUB_ENTERPRISE_APP_URL: "{{ .Values.github.enterpriseAppUrl }}"
     GITHUB_ENTERPRISE_APP_ID: "{{ .Values.github.enterpriseAppId }}"
+    TREX_SETTINGS_ENABLED: "{{ .Values.appConfig.trexSettingsEnabled }}"
+    REPO_CLUSTERS_ENABLED: "{{ .Values.appConfig.repoClustersEnabled }}"
 
 appConfig:
   authSamlOnly: "false"
@@ -118,6 +120,8 @@ appConfig:
   useProceduralMemory: "true"
   defaultExperimentVariant: "rsv11-stndrd4"
   defaultDynamicRouter: "router:reviewNumber:rsv11-stndrd4:rsv16-stndrd4-regated"
+  trexSettingsEnabled: "false"
+  repoClustersEnabled: "false"
 
 github:
   enabled: "false"


### PR DESCRIPTION
## Summary
- Add `TREX_SETTINGS_ENABLED=false` and `REPO_CLUSTERS_ENABLED=false` to the Kubernetes shared env config (applied to all Greptile components).
- Add matching defaults to Docker Compose `.env.example` for new installs via `setup-env.sh`.
- Extend `appConfig` and the Helm values schema with `trexSettingsEnabled` and `repoClustersEnabled` for override support.

## Test plan
- [ ] `helm template` renders shared ConfigMap with both env vars set to `false`
- [ ] Fresh Docker Compose setup from `.env.example` includes both vars
- [ ] Existing deployments can override via `values.user.yaml` (K8s) or `.env` (Docker Compose) if needed


Made with [Cursor](https://cursor.com)