### PR TITLE
Add GITHUB_BOT_USERNAME to Kubernetes shared env

### DIFF
--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -106,6 +106,8 @@ env:
     GITHUB_ENABLED: "{{ .Values.github.enabled }}"
     GITHUB_APP_ID: "{{ .Values.github.appId }}"
     GITHUB_APP_URL: "{{ .Values.github.appUrl }}"
+    GITHUB_BOT_LOGIN: "{{ .Values.github.botLogin }}"
+    GITHUB_BOT_USERNAME: "{{ .Values.github.botUsername }}"
     GITHUB_ENTERPRISE_URL: "{{ .Values.github.enterpriseUrl }}"
     GITHUB_ENTERPRISE_API_URL: "{{ include \"greptile.githubEnterpriseApiUrl\" . }}"
     GITHUB_ENTERPRISE_APP_URL: "{{ .Values.github.enterpriseAppUrl }}"
@@ -136,6 +138,9 @@ github:
   enterpriseEnabled: "true"
   appId: "0"
   appUrl: "https://github.com/apps/dummy-greptile-app"
+  # Used to recognize the app's own PR comments (must match the GitHub App slug / bot user).
+  botLogin: "greptile"
+  botUsername: "greptile[bot]"
   enterpriseUrl: "https://github.example.com"
   enterpriseApiUrl: ""
   enterpriseAppUrl: "https://github.example.com/apps/dummy-greptile-app"

--- a/deploy/kubernetes/charts/profiles/values.user.example.yaml
+++ b/deploy/kubernetes/charts/profiles/values.user.example.yaml
@@ -18,6 +18,9 @@ hatchet:
 github:
   appId: "0"
   appUrl: "https://github.com/apps/REPLACE_ME"
+  # Must match your GitHub App slug so Greptile can find its own prior comments.
+  botLogin: "REPLACE_ME"
+  botUsername: "REPLACE_ME[bot]"
   enterpriseUrl: "https://github.example.com"
   enterpriseAppUrl: "https://github.example.com/apps/REPLACE_ME"
   enterpriseAppId: "0"


### PR DESCRIPTION
## Summary
- Wire `GITHUB_BOT_LOGIN` and `GITHUB_BOT_USERNAME` into the Helm chart shared ConfigMap so self-hosted instances can recognize their own prior PR comments
- Expose configurable `github.botLogin` / `github.botUsername` values (defaults match docker-compose) and document them in `values.user.example.yaml`

## Test plan
- [ ] `helm template` shows `GITHUB_BOT_LOGIN` and `GITHUB_BOT_USERNAME` in the shared env ConfigMap
- [ ] Override `github.botUsername` in user values and confirm the rendered ConfigMap updates
- [ ] On a self-hosted GitHub deploy, confirm Greptile detects its previous comments after setting bot identity to the app slug


Made with [Cursor](https://cursor.com)