### PR TITLE
Add on-prem feature flag configuration

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -119,6 +119,9 @@ AUTH_MIGRATION_ENABLED='false'
 
 # ========= Optional values ===============
 
+# Static on-prem feature flags as a JSON object with boolean values.
+FEATURE_FLAGS_JSON='{}'
+
 REPO_CLUSTERS_ENABLED='true'
 HEADLESS_REVIEW_ENABLED='true'
 
@@ -167,4 +170,3 @@ DEFAULT_DYNAMIC_ROUTER='router:reviewNumber:rsv11-stndrd4:rsv16-stndrd4-regated'
 # mapping gpt-5.5 to whichever GPT variant your provider exposes.
 #REVIEW_WORKFLOW_ROUTING_ENABLED=true
 #DEFAULT_NATIVE_ROUTING_POLICY=native-rod-gpt-simp-v6-composed-primary@1
-

--- a/deploy/kubernetes/charts/greptile/README.md
+++ b/deploy/kubernetes/charts/greptile/README.md
@@ -26,3 +26,16 @@ This chart deploys Greptile application workloads on Kubernetes with parity to t
 - `postgres.enabled=true` uses bundled Bitnami Postgres.
 - Set `postgres.enabled=false` and `externalDatabase.*` for managed DB.
 - Default exposure is Ingress + ClusterIP.
+
+## Feature flags
+
+Set static boolean flags under `features.feature_flags`. The chart serializes
+the map into `FEATURE_FLAGS_JSON` in the shared ConfigMap, which every Greptile
+component receives.
+
+```yaml
+features:
+  feature_flags:
+    new-review-flow: true
+    beta-summary: false
+```

--- a/deploy/kubernetes/charts/greptile/values.schema.json
+++ b/deploy/kubernetes/charts/greptile/values.schema.json
@@ -110,6 +110,16 @@
         }
       }
     },
+    "features": {
+      "type": "object",
+      "required": ["feature_flags"],
+      "properties": {
+        "feature_flags": {
+          "type": "object",
+          "additionalProperties": { "type": "boolean" }
+        }
+      }
+    },
     "env": {
       "type": "object",
       "properties": {

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -96,10 +96,15 @@ storage:
     accessModes:
       - ReadWriteMany
 
+features:
+  # Static on-prem feature flags. Values must be booleans.
+  feature_flags: {}
+
 env:
   shared:
     ONPREM: "true"
     NODE_ENV: "production"
+    FEATURE_FLAGS_JSON: "{{ .Values.features.feature_flags | toJson }}"
     HATCHET_CLIENT_TLS_STRATEGY: "{{ .Values.hatchet.tlsStrategy }}"
     HATCHET_CLIENT_GRPC_BROADCAST_ADDRESS: "{{ .Values.hatchet.grpcUrl }}"
     HATCHET_CLIENT_SERVER_URL: "{{ .Values.hatchet.apiUrl }}"

--- a/deploy/kubernetes/charts/profiles/values.user.example.yaml
+++ b/deploy/kubernetes/charts/profiles/values.user.example.yaml
@@ -15,6 +15,10 @@ hatchet:
   grpcUrl: "hatchet-stack-engine.default.svc.cluster.local:7070"
   tlsStrategy: "none"
 
+# Optional static feature flags for this on-prem deployment.
+features:
+  feature_flags: {}
+
 github:
   appId: "0"
   appUrl: "https://github.com/apps/REPLACE_ME"


### PR DESCRIPTION
## Summary

- add a native `features.feature_flags` boolean map to Helm values
- serialize the map into `FEATURE_FLAGS_JSON` in the shared ConfigMap
- validate flag values through the Helm values schema
- document Helm and Docker Compose configuration

Companion to greptileai/greptilia#10550.

## Testing

- `helm lint deploy/kubernetes/charts/greptile`
- rendered the empty map as `FEATURE_FLAGS_JSON: "{}"`
- rendered enabled and disabled flags as a JSON object
- confirmed API, worker, and webhook reference the shared ConfigMap
- confirmed the schema rejects string flag values
- evaluated the rendered JSON through the Greptilia in-memory provider