### PR TITLE
Pin BoxyHQ Jackson image to 26.2.0

### DIFF
--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -299,7 +299,7 @@ services:
   # ===== SAML SECTION ======
   # Deployed conditionally based on AUTH_SAML_ONLY environment variable
   saml-jackson:
-    image: boxyhq/jackson
+    image: boxyhq/jackson:26.2.0
     hostname: saml-jackson
     restart: on-failure
     profiles:

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -493,7 +493,7 @@ components:
     replicas: 1
     image:
       repository: boxyhq/jackson
-      tag: "latest"
+      tag: "26.2.0"
     containerPort: 5225
     service:
       enabled: true


### PR DESCRIPTION
## Summary
- Pin `boxyhq/jackson` to `26.2.0` in Docker Compose (`saml-jackson`) and the Kubernetes Helm values (`components.jackson`)
- Replaces the untagged / `latest` image so SAML deploys pull a specific Jackson release

## Test plan
- [ ] Confirm `deploy/docker-compose/docker-compose.yaml` uses `boxyhq/jackson:26.2.0`
- [ ] Confirm `deploy/kubernetes/charts/greptile/values.yaml` sets `components.jackson.image.tag` to `26.2.0`
- [ ] If using SAML, start the `saml` profile / enable Jackson in Helm and verify the container comes up on 26.2.0


Made with [Cursor](https://cursor.com)