### PR TITLE
Disable Pylon in on-prem web deployments

### DIFF
--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -176,6 +176,7 @@ services:
       - BILLING_ENABLED=${BILLING}
       - NEXT_PUBLIC_BILLING=${BILLING}
       - NEXT_PUBLIC_ANALYTICS=${ANALYTICS}
+      - PYLON_ENABLED=false
     ports:
       - "3000:3000"
     profiles:

--- a/deploy/kubernetes/charts/greptile/values.yaml
+++ b/deploy/kubernetes/charts/greptile/values.yaml
@@ -248,6 +248,7 @@ components:
       GREPTILE_WEBHOOK_URL: "{{ .Values.network.webhookUrl }}"
       BILLING_ENABLED: "false"
       ANALYTICS: "false"
+      PYLON_ENABLED: "false"
       GITHUB_ENTERPRISE_ENABLED: "{{ .Values.github.enterpriseEnabled }}"
       LINEAR_ENABLED: "{{ .Values.integrations.linearEnabled }}"
       SLACK_ENABLED: "{{ .Values.integrations.slackEnabled }}"


### PR DESCRIPTION
## Summary
- disable Pylon in the Docker Compose web service
- disable Pylon in the Helm web component environment

## Validation
- `helm lint deploy/kubernetes/charts/greptile`
- rendered the Helm chart with `values.user.example.yaml` and confirmed `greptile-web-env` contains `PYLON_ENABLED: "false"`